### PR TITLE
Add missing save modifier to render props

### DIFF
--- a/lib/react/frontier.tsx
+++ b/lib/react/frontier.tsx
@@ -147,7 +147,7 @@ export class Frontier extends Component<FrontierProps, FrontierState> {
   }
 
   renderProps (): FrontierRenderProps {
-    let modifiers: any = {}; // tslint:disable-line no-any
+    let modifiers: any = {save: this.form!.submit}; // tslint:disable-line no-any
     let kit: any = {}; // tslint:disable-line no-any
 
     // for each field, create a `<field>.(change|blur|focus)` modifier function


### PR DESCRIPTION
See #18 / https://frontier-forms.dev/api/frontier-component#modifiers-render-props-argument

If it's supposed to be used as in the UI-kit code sample in the docs (directly in form `onSubmit`) then it should probably also call `preventDefault` on passed event if available.