### PR TITLE
fix(react): added key to form children when using ui-kit

### DIFF
--- a/lib/react/frontier.tsx
+++ b/lib/react/frontier.tsx
@@ -217,7 +217,7 @@ export class Frontier extends Component<FrontierProps, FrontierState> {
       (path, definition, required) => {
         const state = this.form!.getFieldState(path);
         const FieldComponent = this.uiKitComponentFor(path, definition, required);
-        fields[path] = <FieldComponent {...state!} />;
+        fields[path] = <FieldComponent {...state!} key={path} />;
       },
       this.schema!.required || []
     );


### PR DESCRIPTION
React requires each child in a list to have a unique "key" prop - https://fb.me/react-warning-keys
Since each field is already stored using a unique key via "path", we can
also use this as the unique "key" prop.

Closes #29