### PR TITLE
Added onReady hook, and form submit result is now being returned

### DIFF
--- a/lib/data/graphql.ts
+++ b/lib/data/graphql.ts
@@ -84,7 +84,7 @@ export function saveData (
         // FIXME: find a way to handle GQL errors on mutation arguments
         return {};
       } else {
-        return undefined; // submit succeed
+        return result; // submit succeed
       }
     });
   }

--- a/lib/react/frontier.tsx
+++ b/lib/react/frontier.tsx
@@ -40,7 +40,7 @@ export interface FrontierProps extends FrontierDataProps {
   onSave?: (values: object) => void;
   resetOnSave?: boolean;
   order?: string[];
-
+  onReady?: () => void;
   children?: ({ modifiers, state, kit }: FrontierRenderProps) => JSX.Element;
 }
 
@@ -87,6 +87,9 @@ export class Frontier extends Component<FrontierProps, FrontierState> {
             allFormSubscriptionItems
           )();
         }
+
+        // Form is ready
+        if (this.props.onReady) { this.props.onReady(); }
       }
     });
   }


### PR DESCRIPTION
In this PR:
- onReady hook is added and is fired when schema is introspected and forms are built (Close #45)
- Form submission response is now being returned to caller (Close #46)